### PR TITLE
Modification to ensure 3-node cluster are formed

### DIFF
--- a/guides/akka-cluster-kubernetes-k8s-deploy/akka-cluster-example/README.md
+++ b/guides/akka-cluster-kubernetes-k8s-deploy/akka-cluster-example/README.md
@@ -7,7 +7,7 @@ To run the example app, please follow these steps.
 ## Pre-requisite
 
 * A working Kubernetes installation, i.e. an actual Kubernetes cluster or Minikube.
-* Ensure the Docker environment variable is configured to point to the registry used by the Kubernetes cluster.
+* Ensure the Docker environment variable is configured to point to the Kubernetes cluster. If using minikube this is achieved by calling `eval $(minikube docker-env)`.
 
 ## 1. Build the Docker base image
 
@@ -41,7 +41,7 @@ $ kubectl create -f deploy/kubernetes/resources/myapp
 
 ## 4. Confirm the example app is working
 
-Check the logs of the pods created by the example app (i.e. `myapp-0`, `myapp-1`, etc.). The `-f` switch follows the logs emitted by the pod.
+Check the logs of the pods created by the example app (i.e. `myapp-0`, `myapp-1`, and `myapp-2`.). The `-f` switch follows the logs emitted by the pod.
 
 ```bash
 $ kubectl logs -f myapp-0
@@ -53,29 +53,40 @@ Once the app is started within the pod, a log entry similar to the following sho
 [INFO] [10/03/2017 03:44:19.758] [myapp-akka.actor.default-dispatcher-17] [akka.cluster.Cluster(akka://myapp)] Cluster Node [akka.tcp://myapp@myapp-0.myapp.default.svc.cluster.local:2551] - Leader is moving node [akka.tcp://myapp@myapp-0.myapp.default.svc.cluster.local:2551] to [Up]
 ```
 
-The example app exposes the `/members` endpoint which displays the list of members visible for a particular pod. For example, the following displays the list of members visible from `myapp-0` pod:
+Wait for the pods `myapp-0`, `myapp-1`, and `myapp-2` to be at the `Running` state.
+
+Once all these pods are `Running`, query the `/members` endpoint to interrogate the members of the cluster. For example, the following displays the list of members visible from `myapp-0` pod:
 
 ```
 $ kubectl exec -ti myapp-0 -- curl -v myapp-0:9000/members
-  *   Trying 172.17.0.5...
-  * TCP_NODELAY set
-  * Connected to myapp-0 (172.17.0.5) port 9000 (#0)
-  > GET /members HTTP/1.1
-  > Host: myapp-0:9000
-  > User-Agent: curl/7.55.0
-  > Accept: */*
-  >
-  < HTTP/1.1 200 OK
-  < Server: akka-http/10.0.10
-  < Date: Tue, 03 Oct 2017 04:06:32 GMT
-  < Content-Type: application/json
-  < Content-Length: 147
-  <
-  {
-    "members" : [ {
-      "address" : "akka.tcp://myapp@myapp-0.myapp.default.svc.cluster.local:2551",
-      "status" : "Up",
-      "roles" : [ ]
-    } ]
-  * Connection #0 to host myapp-0 left intact
+*   Trying 172.17.0.2...
+* TCP_NODELAY set
+* Connected to myapp-0 (172.17.0.2) port 9000 (#0)
+> GET /members HTTP/1.1
+> Host: myapp-0:9000
+> User-Agent: curl/7.57.0
+> Accept: */*
+>
+< HTTP/1.1 200 OK
+< Server: akka-http/10.0.10
+< Date: Thu, 14 Dec 2017 23:10:28 GMT
+< Content-Type: application/json
+< Content-Length: 401
+<
+{
+  "members" : [ {
+    "address" : "akka.tcp://myapp@myapp-0.myapp.default.svc.cluster.local:2551",
+    "status" : "Up",
+    "roles" : [ ]
+  }, {
+    "address" : "akka.tcp://myapp@myapp-1.myapp.default.svc.cluster.local:2551",
+    "status" : "Up",
+    "roles" : [ ]
+  }, {
+    "address" : "akka.tcp://myapp@myapp-2.myapp.default.svc.cluster.local:2551",
+    "status" : "Up",
+    "roles" : [ ]
+  } ]
+* Connection #0 to host myapp-0 left intact
+}
 ```

--- a/guides/akka-cluster-kubernetes-k8s-deploy/akka-cluster-example/deploy/kubernetes/resources/myapp/myapp-akka-remoting.json
+++ b/guides/akka-cluster-kubernetes-k8s-deploy/akka-cluster-example/deploy/kubernetes/resources/myapp/myapp-akka-remoting.json
@@ -5,7 +5,7 @@
     "labels": {
       "app": "myapp"
     },
-    "name": "myapp-akka-remoting"
+    "name": "myapp"
   },
   "spec": {
     "clusterIP": "None",

--- a/guides/akka-cluster-kubernetes-k8s-deploy/akka-cluster-example/deploy/kubernetes/resources/myapp/myapp-statefulset.json
+++ b/guides/akka-cluster-kubernetes-k8s-deploy/akka-cluster-example/deploy/kubernetes/resources/myapp/myapp-statefulset.json
@@ -6,7 +6,7 @@
   },
   "spec": {
     "serviceName": "myapp",
-    "replicas": 1,
+    "replicas": 3,
     "template": {
       "metadata": {
         "labels": {
@@ -25,16 +25,6 @@
                 "name": "akka-remote"
               }
             ],
-            "resources": {
-              "limits": {
-                "cpu": "250m",
-                "memory": "384Mi"
-              },
-              "requests": {
-                "cpu": "250m",
-                "memory": "384Mi"
-              }
-            },
             "env": [
               {
                 "name": "AKKA_ACTOR_SYSTEM_NAME",
@@ -69,8 +59,8 @@
               "tcpSocket": {
                 "port": 2551
               },
-              "initialDelaySeconds": 30,
-              "timeoutSeconds": 30
+              "initialDelaySeconds": 10,
+              "timeoutSeconds": 120
             }
           }
         ]

--- a/guides/akka-cluster-kubernetes-k8s-deploy/src/main/paradox/index.md
+++ b/guides/akka-cluster-kubernetes-k8s-deploy/src/main/paradox/index.md
@@ -471,7 +471,7 @@ cat << EOF | kubectl create -f -
     "labels": {
       "app": "myapp"
     },
-    "name": "myapp-akka-remoting"
+    "name": "myapp"
   },
   "spec": {
     "clusterIP": "None",
@@ -490,7 +490,7 @@ cat << EOF | kubectl create -f -
 EOF
 ```
 
-This Kubernetes Service has `myapp-akka-remoting` as its name. The service exposes TCP port `2551` which is the application's Akka remoting port.
+This Kubernetes Service has `myapp` as its name. The service exposes TCP port `2551` which is the application's Akka remoting port.
 
 All Pods that have the label `app` with the value of `myapp` will expose the TCP port `2551`.
 
@@ -522,7 +522,7 @@ cat << EOF | kubectl create -f -
   },
   "spec": {
     "serviceName": "myapp",
-    "replicas": 1,
+    "replicas": 3,
     "template": {
       "metadata": {
         "labels": {
@@ -541,16 +541,6 @@ cat << EOF | kubectl create -f -
                 "name": "akka-remote"
               }
             ],
-            "resources": {
-              "limits": {
-                "cpu": "250m",
-                "memory": "384Mi"
-              },
-              "requests": {
-                "cpu": "250m",
-                "memory": "384Mi"
-              }
-            },
             "env": [
               {
                 "name": "AKKA_ACTOR_SYSTEM_NAME",
@@ -565,28 +555,28 @@ cat << EOF | kubectl create -f -
                 "value": "$HOSTNAME.myapp.default.svc.cluster.local"
               },
               {
-                "name": "AKKA_SEED_NODE_PORT",
-                "value": "2551"
+                "name": "AKKA_SEED_NODES",
+                "value": "myapp-0.myapp.default.svc.cluster.local:2551,myapp-1.myapp.default.svc.cluster.local:2551,myapp-2.myapp.default.svc.cluster.local:2551"
               },
               {
-                "name": "AKKA_SEED_NODE_HOST_0",
-                "value": "myapp-0.myapp.default.svc.cluster.local"
+                "name": "HTTP_HOST",
+                "value": "0.0.0.0"
               },
               {
-                "name": "AKKA_SEED_NODE_HOST_1",
-                "value": "myapp-1.myapp.default.svc.cluster.local"
+                "name": "HTTP_PORT",
+                "value": "9000"
               },
               {
-                "name": "AKKA_SEED_NODE_HOST_2",
-                "value": "myapp-2.myapp.default.svc.cluster.local"
+                "name": "CLUSTER_MEMBERSHIP_ASK_TIMEOUT",
+                "value": "5000"
               }
             ],
             "readinessProbe": {
               "tcpSocket": {
                 "port": 2551
               },
-              "initialDelaySeconds": 30,
-              "timeoutSeconds": 30
+              "initialDelaySeconds": 10,
+              "timeoutSeconds": 120
             }
           }
         ]
@@ -599,7 +589,7 @@ EOF
 
 The StatefulSet for the application has `myapp` as the name as declared by `spec.serviceName`.
 
-The StatefulSet has `1` replica. You may adjust this number to the number of instances you desire. Alternatively, you can deploy the with `1` replica to begin with, and once the first service is started you may adjust this number by modifying the StatefulSet:
+The StatefulSet has `3` replica. You may adjust this number to the number of instances you desire. Alternatively, you can deploy the with `1` replica to begin with, and once the first service is started you may adjust this number by modifying the StatefulSet:
 
 ```bash
 kubectl scale statefulsets myapp --replicas=3


### PR DESCRIPTION
* Fix the incorrect service name.
* Adjust number of replicas to 3.
* Remove the resource constraint, leaving it at default. This is because the existing resource constraint is too large with default minikube settings, sufficient only for 2 out of 3 replicas.
* Update the README with this changes.